### PR TITLE
fix: Implement CSS checkbox hack for reliable mobile menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="index.html">Accueil</a></li>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -58,16 +58,24 @@ header {
     align-items: center;
 }
 
-.menu-toggle {
-    display: none;
-    background: none;
-    border: none;
-    color: var(--text-primary);
-    font-size: 1.8rem;
-    cursor: pointer;
+/* CSS Checkbox Hack for Mobile Menu */
+.menu-toggle-input {
+    display: none; /* Hide the actual checkbox */
 }
 
-header ul {
+.menu-toggle-label {
+    display: none; /* Hidden by default, shown only on mobile */
+    cursor: pointer;
+    font-size: 28px;
+    color: var(--text-primary);
+    position: absolute;
+    top: 15px;
+    right: 20px;
+    z-index: 1006;
+    line-height: 1;
+}
+
+header nav ul { /* Changed from 'header ul' to be more specific if direct 'ul' children of header exist elsewhere */
     list-style: none;
     padding: 0;
     margin: 0;
@@ -322,40 +330,41 @@ img {
 }
 
 @media (max-width: 768px) {
-    header ul {
+    .menu-toggle-label {
+        display: block;
+    }
+
+    header nav ul {
         display: none;
         flex-direction: column;
+        align-items: center;
+
         position: fixed;
         top: 0;
         left: 0;
         width: 100%;
-        height: 100%;
+        height: 100vh;
+
         background-color: var(--card-bg);
-        padding: 20px 0;
+        padding: 60px 20px 20px;
+
         z-index: 1005;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
-        opacity: 0;
-        transform: translateY(-20px);
-        transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out; /* Updated transition */
-        align-items: center;
     }
-    header ul.show {
-        display: flex;
-        opacity: 1;
-        transform: translateY(0);
-    }
-    header ul li {
+
+    header nav ul li {
         text-align: center;
-        padding: 15px 0;
+        padding: 0; /* Remove padding from li, will add to a */
         width: 100%;
     }
-    .menu-toggle {
+    header nav ul li a {
         display: block;
-        position: absolute;
-        top: 15px;
-        right: 20px;
-        z-index: 1006;
+        padding: 15px 0; /* Consistent padding for tap target */
     }
+
+    #menu-toggle-input:checked ~ nav ul {
+        display: flex;
+    }
+
     .cta-buttons {
         flex-direction: column;
         gap: 10px;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -71,13 +71,3 @@ document.querySelectorAll('.btn').forEach(btn => {
         gsap.to(btn, { scale: 1, duration: 0.2 });
     });
 });
-
-// Gestion du menu responsive avec le bouton hamburger
-const menu = document.querySelector("nav ul");
-const toggleBtn = document.querySelector(".menu-toggle");
-
-if (toggleBtn) {
-    toggleBtn.addEventListener("click", () => {
-        menu.classList.toggle("show");
-    });
-}

--- a/certifications.html
+++ b/certifications.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="index.html">Accueil</a></li>

--- a/contact.html
+++ b/contact.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="index.html">Accueil</a></li>

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
 
 <body>
   <header>
-    <button class="menu-toggle">☰</button>
-
+    <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+    <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
     <nav>
       <ul>
         <li><a href="index.html">Accueil</a></li>

--- a/parcours.html
+++ b/parcours.html
@@ -12,7 +12,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="index.html">Accueil</a></li>

--- a/projet.html
+++ b/projet.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="index.html">Accueil</a></li>

--- a/projets/projet1.html
+++ b/projets/projet1.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="../index.html">Accueil</a></li>

--- a/projets/projet2.html
+++ b/projets/projet2.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="../index.html">Accueil</a></li>

--- a/projets/stage.html
+++ b/projets/stage.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="../index.html">Accueil</a></li>

--- a/stage.html
+++ b/stage.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="index.html">Accueil</a></li>

--- a/stage/stage1.html
+++ b/stage/stage1.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="../index.html">Accueil</a></li>

--- a/stage/stage2.html
+++ b/stage/stage2.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="../index.html">Accueil</a></li>

--- a/stage/stage3.html
+++ b/stage/stage3.html
@@ -11,7 +11,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="../index.html">Accueil</a></li>

--- a/veille.html
+++ b/veille.html
@@ -10,7 +10,8 @@
 
 <body>
     <header>
-        <button class="menu-toggle">☰</button>
+        <input type="checkbox" id="menu-toggle-input" class="menu-toggle-input">
+        <label for="menu-toggle-input" class="menu-toggle-label">☰</label>
         <nav>
             <ul>
                 <li><a href="index.html">Accueil</a></li>


### PR DESCRIPTION
Replaces the previous JavaScript-based mobile menu toggle with a pure CSS solution (the "Checkbox Hack") to ensure reliable functionality.

Key changes:

- Removed the old `<button class="menu-toggle">` from all HTML files.
- Deleted the associated JavaScript toggle logic from `assets/js/main.js`.
- Integrated new HTML structure (`<input type="checkbox" id="menu-toggle-input">` and `<label for="menu-toggle-input">`) into all relevant HTML files for the checkbox hack.
- Added new CSS rules to `assets/css/styles.css`:
    - Hides the actual checkbox.
    - Styles the label to act as the hamburger menu icon, visible only on mobile.
    - Controls the visibility of the main navigation menu (`header nav ul`) based on the checkbox's checked state.
    - Ensures the mobile menu displays as a full-screen overlay.
    - Desktop navigation remains unaffected.
- Removed old CSS rules related to the previous JavaScript-based menu.

This change addresses your feedback regarding the unreliability of the previous mobile menu and provides a more robust, CSS-only solution.